### PR TITLE
Fix: Glob pattern matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+graficos
+datos

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ Path('datos').mkdir(exist_ok=True)
 Path('graficos').mkdir(exist_ok=True)
 
 # Leer todos los archivos CSV en la carpeta
-archivos_csv = glob.glob(str(ruta_carpeta / '*.csv'))
+archivos_csv = ruta_carpeta.glob('*.CSV')
 
 periodo_muestreo = 4
 


### PR DESCRIPTION
Las extensiones de los archivos son UPPERCASE pero el codigo original buscaba archivos con extension en minuscula. 

> Tambien agregue un gitignore